### PR TITLE
Fix mapRegex - <prefix> didn't include everything up to the version string.

### DIFF
--- a/src/versioning/versioning.py
+++ b/src/versioning/versioning.py
@@ -97,8 +97,8 @@ class ScalaText:
 mapRegex = {
     'begin' : re.compile(r'\bval defaultVersions\s*=\s*(Map|Seq)\('),
     # Support both old ( "package" -> "version") and new (ModuleID) specifications
-    'oldentry' : re.compile(r'(?P<prefix>(.*))"(?P<packageName>([\w-]+))"\s*->\s*"(?P<version>(' + CNVersion.versionRegex.pattern + '))(?P<suffix>("(?P<lineend>(.*))))$'),
-    'moduleId' : re.compile(r'(?P<prefix>(.*))"(?P<organizationName>([^"]*))"\s*%%\s*"(?P<packageName>([\w-]+))"\s*%\s*"(?P<version>(' + CNVersion.versionRegex.pattern + '))(?P<suffix>("(?P<lineend>(.*))))$'),
+    'oldentry' : re.compile(r'(?P<prefix>(.*)"(?P<packageName>([\w-]+))"\s*->\s*")(?P<version>(' + CNVersion.versionRegex.pattern + '))(?P<suffix>("(?P<lineend>(.*))))$'),
+    'moduleId' : re.compile(r'(?P<prefix>(.*)"(?P<organizationName>([^"]*))"\s*%%\s*"(?P<packageName>([\w-]+))"\s*%\s*")(?P<version>(' + CNVersion.versionRegex.pattern + '))(?P<suffix>("(?P<lineend>(.*))))$'),
     'end' : re.compile(r'\)')
 }
 


### PR DESCRIPTION
This broke an attempt to update version strings in defaultVersions Map/Seq - it dropped the `"module name" -> "` component.
