### PR TITLE
Fix mergify logic for labeling backports

### DIFF
--- a/scripts/mergify.sc
+++ b/scripts/mergify.sc
@@ -45,7 +45,7 @@ def mergeToMaster(conditions: List[String]) = Json.obj(
 val labelMergifyBackport = Json.obj(
   "name" -> "label Mergify backport PR".asJson,
   "conditions" -> List(
-    """body~=This is an automated backport of pull request \#\d+ done by Mergify"""
+    """title~=\(bp \#\d+\)"""
   ).asJson,
   "actions" -> Json.obj(
     "label" -> Json.obj(


### PR DESCRIPTION
Used to generate https://github.com/chipsalliance/firrtl/pull/2048, see that PR for context