### PR TITLE
Cleanup of argument parsing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,23 +6,27 @@ The pages here are taken from the release document authored by Jim Lawson. This 
 herein. The scripts are the final ground truth over the current process and differences found should cause these pages
 to be updated.
 
+---
+
+## How To:
+
+### [Publish a SNAPSHOT release](publish_snapshots.md)
+
+### [Publish a minor release](publish_minor_release.md)
+
+### [Publish a major release](publish_major_release.md)
+
+### [Generating a Mergify File](generate_mergify.md)
+
+---
+
 ## Overview
-
-### How To Publish
-
-#### [Publish a SNAPSHOT release](publish_snapshots.md)
-
-#### [Publish a minor release](publish_minor_release.md)
-
-#### [Publish a major release](publish_major_release.md)
 
 ### [Release Basics](release_basics.md)
 
 ### [Release Process Details](release_process_details.md)
 
 ### [Generating Change Logs](generate_changelog.md)
-
-### [Generating a Mergify File](generate_mergify.md)
 
 ## Setup and General information
 

--- a/docs/publish_snapshots.md
+++ b/docs/publish_snapshots.md
@@ -26,8 +26,9 @@ snapshots.
 
 ```
 chisel-repo-tools chick$ python publish/publish_snapshots.py --help
-usage: publish_snapshots.py [-h] -r RELEASE_DIR -m MAJOR_VERSION [-d] [-o DATE_STAMP] [-b START_STEP]
-                            [-e STOP_STEP] [-l]
+usage: publish_snapshots.py [-h] -r RELEASE_DIR -m MAJOR_VERSION [-d]
+                            [-o DATE_STAMP] [-b START_STEP] [-e STOP_STEP]
+                            [-l]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -37,12 +38,14 @@ optional arguments:
                         major number of snapshots being published
   -d, --dated-snapshot  add datestamp to snapshots
   -o DATE_STAMP, --override-date DATE_STAMP
-                        overrides the date used for dated snapshots, format YYYYMMDD
+                        overrides the date used for dated snapshots, format
+                        YYYYMMDD
   -b START_STEP, --start-step START_STEP
                         command step to start on
   -e STOP_STEP, --stop-step STOP_STEP
                         command step to end on
   -l, --list-only       list command step, do not execute
+
 
 ```
 

--- a/publish/bump-type.py
+++ b/publish/bump-type.py
@@ -6,105 +6,70 @@ publishSigned everything
 
 import os
 import sys
-import getopt
+from argparse import ArgumentParser
 
 from publish_utils.tools import Tools
 from publish_utils.step_counter import StepCounter
 
 
-def usage():
-    print(f"Usage: {sys.argv[0]} --repo <repo-dir> --release <release-major-number> --bump-type <bump-type> [options]")
-    print(f"options are:")
-    print(f"     --repo       <repo>          repo most be a clone of chisel-release")
-    print(f"     --bump-type  <bump-type>     must be one of the following")
-    print(f"                   major          bumps the major number of the release")
-    print(f"                   minor          bumps the minor number of the release")
-    print(f"                   rc<n>          set release candidate to the number n")
-    print(f"                   rc-clear       clears the release candidate number")
-    print(f"                   ds             create datestamped snapshot using todays date")
-    print(f"                   ds<YYYMMDD>    create datestamped snapshot using date specified in YYYYMMDD format")
-    print(f"                   ds-clear       clear date to create undate stamped snapshot")
-    print(f"     --start-step <start_step>    (or -s)")
-    print(f"     --stop-step  <stop_step>     (or -e)")
-    print(f"     --list-only                  (or -l)")
-    print(f"")
-    print(f"  Note: --release (-m) defines the major of the release being snapshotted, e.g. '3.4'")
-
-
 def main():
     try:
-        opts, args = getopt.getopt(
-            sys.argv[1:],
-            "lhr:m:s:e:",
-            ["help", "repo=", "release=", "bump-type=", "start-step=", "stop-step=", "list-only"]
-        )
-    except getopt.GetoptError as err:
-        print(err)
-        usage()
-        sys.exit(2)
+        parser = ArgumentParser()
+        parser.add_argument('-r', '--release-dir', dest='release_dir', action='store',
+                            help='a directory which is a clone of chisel-release default is "."', default=".")
+        parser.add_argument('-bt', '--bump-type', dest='bump_type', action='store', choices=['major', 'minor'],
+                            help='Is this a major or a minor release',
+                            required=True)
+        Tools.add_standard_cli_arguments(parser)
 
-    release_dir = ""
-    start_step = -1
-    stop_step = 1000
-    list_only = False
-    bump_type = ""
-    counter = StepCounter()
+        args = parser.parse_args()
 
-    for option, value in opts:
-        if option in ("--repo", "-r"):
-            release_dir = value
-        elif option in ("--bump-type", "-b"):
-            bump_type = f"{value}"
-        elif option in ("--start-step", "-s"):
-            start_step = int(value)
-        elif option in ("--stop-step", "-e"):
-            stop_step = int(value)
-        elif option in ("--list-only", "-l"):
-            list_only = True
-        elif option in ("--help", "-h"):
-            usage()
+        release_dir = args.release_dir
+        bump_type = args.bump_type
+        start_step = args.start_step
+        stop_step = args.stop_step
+        list_only = args.list_only
+        counter = StepCounter()
+
+        if release_dir == "":
+            print(f"Error: both --repo and --release must be specified to run this script")
+            parser.print_help()
             exit(1)
         else:
-            print(f"Unhandled command line option: {option}")
-            usage()
-            assert False
+            print(f"chisel-release directory is {os.getcwd()}")
 
-    if release_dir == "":
-        print(f"Error: both --repo and --release must be specified to run this script")
-        usage()
-        exit(1)
-    else:
-        print(f"chisel-release directory is {os.getcwd()}")
+        if not list_only:
+            # this will validate bump_tpe and exit on failure
+            Tools.get_versioning_command(bump_type)
+        else:
+            print(f"These are the steps to be executed for the {sys.argv[0]} script")
 
-    if not list_only:
-        # this will validate bump_tpe and exit on failure
-        Tools.get_versioning_command(bump_type)
-    else:
-        print(f"These are the steps to be executed for the {sys.argv[0]} script")
+        tools = Tools("set_dated_snapshots", release_dir)
 
-    tools = Tools("set_dated_snapshots", release_dir)
+        tools.set_start_step(start_step)
+        tools.set_stop_step(stop_step)
+        tools.set_list_only(list_only)
 
-    tools.set_start_step(start_step)
-    tools.set_stop_step(stop_step)
-    tools.set_list_only(list_only)
+        #
+        # Change repo's release versions and references
+        # according to the 'bumptype'
+        #
+        tools.bump_release(counter.next_step(), bump_type)
+        tools.check_version_updates(counter.next_step())
+        tools.publish_signed(counter.next_step())
 
-    #
-    # Change repo's release versions and references
-    # according to the 'bumptype'
-    #
-    tools.bump_release(counter.next_step(), bump_type)
-    tools.check_version_updates(counter.next_step())
-    tools.publish_signed(counter.next_step())
-
-    tools.comment(
-        counter.next_step(),
-        f"""
-        You are almost done
-            - Follow steps in docs/sonatype_finalize_release.md
-            - Then publish/tag_release
-            - Then run generate snapshots
-        """
-    )
+        tools.comment(
+            counter.next_step(),
+            f"""
+            You are almost done
+                - Follow steps in docs/sonatype_finalize_release.md
+                - Then publish/tag_release
+                - Then run generate snapshots
+            """
+        )
+    except Exception as e:
+        print(e)
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/publish/generate_changelog.py
+++ b/publish/generate_changelog.py
@@ -14,26 +14,19 @@ def main():
 
     try:
         parser = ArgumentParser()
-        parser.add_argument('-r', '--release', dest='release_dir', action='store',
-                            help='a directory which is a clone of chisel-release', required=True)
+        parser.add_argument('-r', '--release-dir', dest='release_dir', action='store',
+                            help='a directory which is a clone of chisel-release, default is "."', default=".")
         parser.add_argument('-m', '--major-version', dest='major_version', action='store',
                             help='major number of snapshots being published', required=True)
         parser.add_argument('-d', '--date-range', dest='date_range', action='store',
-                            help='set dates to search for PRs, e.g. ">2021-04-01" or "2021-05-01..2021-05-31',
+                            help='set dates to search for PRs, e.g. ">2021-04-01" or "2021-05-31..2021-05-01',
                             default=current_date)
         parser.add_argument('-c', '--clear-db', dest='clear_db', action='store_true',
                             help='clears issues collection from each repo database before downloading', default=False)
         parser.add_argument('-g', '--github-token', dest='github_token', action='store',
                             help='Way to set your github token, will use env var GHRPAT if not set by this',
                             default="")
-        parser.add_argument('-b', '--start-step', dest='start_step', type=int, action='store',
-                            help='command step to start on',
-                            default=1)
-        parser.add_argument('-e', '--stop-step', dest='stop_step', type=int, action='store',
-                            help='command step to end on',
-                            default=10000)
-        parser.add_argument('-l', '--list-only', dest='list_only', action='store_true',
-                            help='list command step, do not execute', default=False)
+        Tools.add_standard_cli_arguments(parser)
 
         args = parser.parse_args()
 

--- a/publish/merge_master_into_dot_x.py
+++ b/publish/merge_master_into_dot_x.py
@@ -59,7 +59,7 @@ def main():
         tools.run_submodule_update_recursive(counter.next_step())
         tools.run_make_pull(counter.next_step())
         tools.git_add_dash_u(counter.next_step())
-        tools.git_commit(counter.next_step(), "Bump .x branches")
+        tools.git_commit(counter.next_step(), "Bump master branches")
         tools.git_push(counter.next_step())
 
         #
@@ -71,7 +71,7 @@ def main():
         tools.run_make_pull(counter.next_step())
         tools.git_merge_masters_into_dot_x(counter.next_step())
         tools.git_add_dash_u(counter.next_step())
-        tools.git_commit(counter.next_step(), "Bump .x branches")
+        tools.git_commit(counter.next_step(), "Bump .x branches that just had masters merged into them")
         tools.git_push(counter.next_step())
 
     except Exception as e:

--- a/publish/publish_new_release.py
+++ b/publish/publish_new_release.py
@@ -15,7 +15,8 @@ def main():
                             help='a directory which is a clone of chisel-release default is "."', default=".")
         parser.add_argument('-m', '--major-version', dest='major_version', action='store',
                             help='major number of release being bumped', required=True)
-        parser.add_argument('-bt', '--bump-type', dest='bump_type', action='store', choices=['major', 'minor'],
+        parser.add_argument('-bt', '--bump-type', dest='bump_type', action='store',
+                            choices=['major', 'minor', 'rc<n>', 'rc=clear', 'ds', 'ds<YYYYMMDD', 'ds-clear'],
                             help='Is this a major or a minor release',
                             required=True)
         Tools.add_standard_cli_arguments(parser)

--- a/publish/publish_snapshots.py
+++ b/publish/publish_snapshots.py
@@ -14,24 +14,17 @@ def main():
 
     try:
         parser = ArgumentParser()
-        parser.add_argument('-r', '--release', dest='release_dir', action='store',
-                            help='a directory which is a clone of chisel-release', required=True)
+        parser.add_argument('-r', '--release-dir', dest='release_dir', action='store',
+                            help='a directory which is a clone of chisel-release', default=".")
         parser.add_argument('-m', '--major-version', dest='major_version', action='store',
                             help='major number of snapshots being published', required=True)
         parser.add_argument('-d', '--dated-snapshot', dest='is_dated_snapshot', action='store_true',
-                            help='add datestamp to snapshots',
+                            help="add today's date asdatestamp to snapshots",
                             default=False)
         parser.add_argument('-o', '--override-date', dest='date_stamp', action='store',
                             help='overrides the date used for dated snapshots, format YYYYMMDD',
                             default=current_date)
-        parser.add_argument('-b', '--start-step', dest='start_step', type=int, action='store',
-                            help='command step to start on',
-                            default=1)
-        parser.add_argument('-e', '--stop-step', dest='stop_step', type=int, action='store',
-                            help='command step to end on',
-                            default=10000)
-        parser.add_argument('-l', '--list-only', dest='list_only', action='store_true',
-                            help='list command step, do not execute', default=False)
+        Tools.add_standard_cli_arguments(parser)
 
         args = parser.parse_args()
 

--- a/publish/publish_utils/step_counter.py
+++ b/publish/publish_utils/step_counter.py
@@ -1,4 +1,3 @@
-
 class StepCounter:
     def __init__(self):
         self.step_counter = 0

--- a/publish/test_submodules.py
+++ b/publish/test_submodules.py
@@ -73,5 +73,6 @@ def main():
 
     tools.run_make_test(counter.next_step())
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Reorganized the index.md
- Updated publish_snapshots.md
- Add checks that release dir targeted is a clone of `chisel-release`
- Fixed path bug in tools.py when calling gitlog2releasenotes.py
- Conver bumptype.py to argparse
- Standardize args parsing in generate_changelog.py
- Made cosmetic fixes to commit messages in merge_master_into_dot_x.py
- Add all bump-type options to publish_snapshots.md
- Standardize args parsing in publish_snapshots.py