### PR TITLE
Dockerized release

### DIFF
--- a/publish/publish_new_release.py
+++ b/publish/publish_new_release.py
@@ -8,19 +8,24 @@ from publish_utils.tools import Tools
 from publish_utils.step_counter import StepCounter
 
 
+def make_parser():
+    parser = ArgumentParser()
+    parser.add_argument('-r', '--release-dir', dest='release_dir', action='store',
+            help='a directory which is a clone of chisel-release default is "."', default=".")
+    parser.add_argument('-m', '--major-version', dest='major_version', action='store',
+            help='major number of release being bumped', required=True)
+    parser.add_argument('-bt', '--bump-type', dest='bump_type', action='store',
+            choices=['major', 'minor', 'rc<n>', 'rc=clear', 'ds', 'ds<YYYYMMDD', 'ds-clear'],
+            help='Is this a major or a minor release',
+            required=True)
+    Tools.add_standard_cli_arguments(parser)
+
+    return parser
+
+
 def main():
     try:
-        parser = ArgumentParser()
-        parser.add_argument('-r', '--release-dir', dest='release_dir', action='store',
-                            help='a directory which is a clone of chisel-release default is "."', default=".")
-        parser.add_argument('-m', '--major-version', dest='major_version', action='store',
-                            help='major number of release being bumped', required=True)
-        parser.add_argument('-bt', '--bump-type', dest='bump_type', action='store',
-                            choices=['major', 'minor', 'rc<n>', 'rc=clear', 'ds', 'ds<YYYYMMDD', 'ds-clear'],
-                            help='Is this a major or a minor release',
-                            required=True)
-        Tools.add_standard_cli_arguments(parser)
-
+        parser = make_parser()
         args = parser.parse_args()
 
         release_dir = args.release_dir

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""publishes a new release, either major or minor"""
+
+import os
+import sys
+from argparse import ArgumentParser
+import subprocess
+
+def gitConfigGet(value):
+    cmd = ["git", "config", "--get", value]
+    proc = subprocess.run(cmd, capture_output=True)
+    if proc.returncode != 0:
+        msg = f"Could not determine git config value for '{value}', please provide one via CLI"
+        raise Exception(msg)
+    value = proc.stdout.decode().strip()
+    return value
+
+
+def makeParser():
+    # TODO expose and propagate options from 'publish_new_release.py'
+    parser = ArgumentParser()
+    parser.add_argument("-e", "--email", action="store", default=gitConfigGet("user.email"),
+                        help="Git config user.email, defaults to `git config --get user.email")
+    parser.add_argument("-n", "--name", action="store", default=gitConfigGet("user.name"),
+                        help="Git config user.name, defaults to `git config --get user.name")
+    return parser
+
+
+def main():
+    parser = makeParser()
+    args = parser.parse_args()
+    print(args)
+
+    # Step 1 - Build Docker Image
+    # TODO actually do this
+    # Run from root of the repo
+    # docker build -f resources/Dockerfile -t chiselrelease:latest .
+
+    # Step 2 - Run release
+    # TODO figure out how to have the Docker container stick around if it fails or go away if it passes
+    environment = {
+        "PYTHONPATH": "/work/chisel-repo-tools",
+        "VERSIONING": "$PYTHONPATH/versioning/versioning.py"
+    }
+    lines = [
+        f"git config --global user.email {args.email}",
+        f"git config --global user.name {args.name}",
+        f"git config -l",
+        "hostname"
+    ]
+    joined = "; ".join(lines)
+    script = f"bash -c '{joined}'"
+    cmd = ["docker", "run", "--rm", "-it", "chiselrelease:latest", "bash", "-c", joined]
+    proc1 = subprocess.run(["echo", "$PATH"], shell=True)
+    print(proc1)
+    print(cmd)
+    proc = subprocess.run(cmd, capture_output=True)
+    print(proc.stdout.decode())
+    print(proc.stderr.decode())
+
+
+if __name__ == "__main__":
+    main()

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -2,6 +2,7 @@
 """publishes a new release, either major or minor"""
 
 import os
+from os.path import expandvars
 import sys
 from argparse import ArgumentParser
 import subprocess
@@ -15,14 +16,39 @@ def gitConfigGet(value):
     value = proc.stdout.decode().strip()
     return value
 
+def platform():
+    if sys.platform == "darwin":
+        return "macos"
+    elif sys.platform.startswith("linux"):
+        return "linux"
+    else:
+        raise Exception(f"Unsupported platform {sys.platform}")
+
+
+def platformSpecific(key):
+    lookup = {
+        "macos": {
+            "sshagent": "/run/host-services/ssh-auth.sock"
+        },
+        "linux": {
+            "sshagent": "$SSH_AUTH_SOCK" # TODO may need to do env lookup
+        }
+    }
+    return lookup[platform()][key]
+
+
+def sshAgent():
+    return platformSpecific("sshagent")
 
 def makeParser():
     # TODO expose and propagate options from 'publish_new_release.py'
     parser = ArgumentParser()
     parser.add_argument("-e", "--email", action="store", default=gitConfigGet("user.email"),
-                        help="Git config user.email, defaults to `git config --get user.email")
+                        help="Git config user.email, defaults to 'git config --get user.email'")
     parser.add_argument("-n", "--name", action="store", default=gitConfigGet("user.name"),
-                        help="Git config user.name, defaults to `git config --get user.name")
+                        help="Git config user.name, defaults to 'git config --get user.name'")
+    parser.add_argument("--ssh-agent", action="store", default=sshAgent(),
+                        help=f"Git config user.name, defaults to '{sshAgent()}'")
     return parser
 
 
@@ -30,6 +56,9 @@ def main():
     parser = makeParser()
     args = parser.parse_args()
     print(args)
+
+    container_home = "/root"
+    host_home = expandvars("$HOME")
 
     # Step 1 - Build Docker Image
     # TODO actually do this
@@ -46,17 +75,23 @@ def main():
         f"git config --global user.email {args.email}",
         f"git config --global user.name {args.name}",
         f"git config -l",
-        "hostname"
+        "hostname",
+        f"git clone git@github.com:chipsalliance/treadle.git"
     ]
     joined = "; ".join(lines)
     script = f"bash -c '{joined}'"
-    cmd = ["docker", "run", "--rm", "-it", "chiselrelease:latest", "bash", "-c", joined]
+    base_cmd = ["docker", "run", "--rm", "-it"]
+    # SSH Agent forwarding
+    ssh_agent = ["-v", f"{args.ssh_agent}:/ssh-agent", "-e", "SSH_AUTH_SOCK=/ssh-agent"]
+    # Known hosts mapping
+    known_hosts = ["-v", f"{host_home}/.ssh/known_hosts:{container_home}/.ssh/known_hosts"]
+    cmd =  base_cmd + ssh_agent + known_hosts + [ "chiselrelease:latest", "bash", "-c", joined]
     proc1 = subprocess.run(["echo", "$PATH"], shell=True)
     print(proc1)
     print(cmd)
-    proc = subprocess.run(cmd, capture_output=True)
-    print(proc.stdout.decode())
-    print(proc.stderr.decode())
+    proc = subprocess.run(cmd) #, capture_output=True)
+    #print(proc.stdout.decode())
+    #print(proc.stderr.decode())
 
 
 if __name__ == "__main__":

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
 """Example use: ./publish/publish_new_release_in_docker.py -- -m 3.4 -bt minor"""
+# Useful commands
+# # Build the docker file
+# > docker build -f resources/Dockerfile -t chiselrelease:latest .
+#
+# # Connect to a running container
+# > docker exec -it <container> bash
+#
+# # Stop a container
+# > docker stop <container>
+#
+# # Delete all stopped containers
+# > docker container prune
 
 import os
 from os.path import expandvars

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""publishes a new release, either major or minor"""
+"""Example use: ./publish/publish_new_release_in_docker.py -- -m 3.4 -bt minor"""
 
 import os
 from os.path import expandvars
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 import subprocess
 import shutil
 from pathlib import Path
+import publish_new_release as pnr
 
 def gitConfigGet(value):
     cmd = ["git", "config", "--get", value]
@@ -72,7 +73,55 @@ def makeParser():
                         help="Git config user.name, defaults to 'git config --get user.name'")
     parser.add_argument("--ssh-agent", action="store", default=sshAgent(),
                         help=f"Git config user.name, defaults to '{sshAgent()}'")
+    parser.add_argument("args", type=str, nargs="+",
+                        help="Arguments for publish_new_release.py that will be run in Docker container")
     return parser
+
+
+def find_container(image_name):
+    cmd = ["docker", "ps", "--filter", f"ancestor={image_name}", "-q"]
+    proc = subprocess.run(cmd, capture_output=True)
+    lines = proc.stdout.decode().strip().split("\n")
+
+    res = [x for x in lines if x != ""]
+
+    if len(res) > 1:
+        raise SystemExit(f"There needs to be 1 or fewer {image_name} containers, got {res}!")
+    if len(res) == 0:
+        return None
+    else:
+        return res[0]
+
+
+def launch_container(args, image_name):
+    container_home = "/root"
+    host_home = expandvars("$HOME")
+
+    # SSH Agent forwarding
+    ssh_agent = ["-v", f"{args.ssh_agent}:/ssh-agent", "-e", "SSH_AUTH_SOCK=/ssh-agent"]
+    # Known hosts mapping
+    known_hosts = ["-v", f"{host_home}/.ssh/known_hosts:{container_home}/.ssh/known_hosts"]
+
+    base_cmd = ["docker", "run", "-t", "-d"]
+    cmd =  base_cmd + ssh_agent + known_hosts + [image_name]
+
+    proc = subprocess.run(cmd, capture_output=True)
+
+    return proc.stdout.decode().strip()
+
+
+def run_commands(args, container, environment, lines):
+    all_lines = [
+        f"git config --global user.email {args.email}",
+        f"git config --global user.name {args.name}",
+    ] + lines
+    joined = "; ".join(all_lines)
+    script = f"bash -c '{joined}'"
+    base_cmd = ["docker", "exec"]
+    env = flatten([["-e", f"{name}={value}"] for name, value in environment.items()])
+    cmd = base_cmd + env + [container] + ["bash", "-c", joined]
+    print(prettifyCommand(cmd))
+    proc = subprocess.run(cmd)
 
 
 def main():
@@ -80,47 +129,47 @@ def main():
     args = parser.parse_args()
     print(args)
 
-    container_home = "/root"
-    host_home = expandvars("$HOME")
+    # Check forwarded args
+    forwarded_args = args.args
+    pnr_parser = pnr.make_parser()
+    pnr_parser.parse_args(forwarded_args)
+
+    image_name = "chiselrelease:latest"
 
     # Step 1 - Build Docker Image
     # TODO actually do this
     # Run from root of the repo
     # docker build -f resources/Dockerfile -t chiselrelease:latest .
 
-    # Step 2 - Run release
-    # TODO figure out how to have the Docker container stick around if it fails or go away if it passes
-
+    # Environment needed to run publish commands
     environment = formatValues({
         "PYTHONPATH": "/work/chisel-repo-tools/src",
         "VERSIONING": "{PYTHONPATH}/versioning/versioning.py",
     })
-    lines = [
-        f"git config --global user.email {args.email}",
-        f"git config --global user.name {args.name}",
-        f"git config -l",
-        "hostname",
-        f"git clone git@github.com:ucb-bar/chisel-release.git",
-        f"cd chisel-release",
-        f"python3 ../publish/publish_new_release.py -m 3.4 -bt minor"
 
+    # Find or launch container
+    container = find_container(image_name)
+
+    if container is None:
+        print("No container running, starting...")
+        container = launch_container(args, image_name)
+        cmd = ["git clone git@github.com:ucb-bar/chisel-release.git"]
+        run_commands(args, container, environment, cmd)
+
+    print(f"Running in container {container}")
+
+
+    # Step 2 - Run release
+    # TODO figure out how to have the Docker container stick around if it fails or go away if it passes
+
+    splat_args = " ".join(forwarded_args)
+
+    lines = [
+        "cd chisel-release",
+        f"python3 ../chisel-repo-tools/publish/publish_new_release.py {splat_args}"
     ]
-    joined = "; ".join(lines)
-    script = f"bash -c '{joined}'"
-    base_cmd = ["docker", "run", "--rm", "-it"]
-    # SSH Agent forwarding
-    ssh_agent = ["-v", f"{args.ssh_agent}:/ssh-agent", "-e", "SSH_AUTH_SOCK=/ssh-agent"]
-    # Known hosts mapping
-    known_hosts = ["-v", f"{host_home}/.ssh/known_hosts:{container_home}/.ssh/known_hosts"]
-    env = flatten([["-e", f"{name}={value}"] for name, value in environment.items()])
-    cmd =  base_cmd + env + ssh_agent + known_hosts + [ "chiselrelease:latest", "bash", "-c", joined]
-    print(prettifyCommand(cmd))
-    proc1 = subprocess.run(["echo", "$PATH"], shell=True)
-    print(proc1)
-    print(cmd)
-    proc = subprocess.run(cmd) #, capture_output=True)
-    #print(proc.stdout.decode())
-    #print(proc.stderr.decode())
+
+    run_commands(args, container, environment, lines)
 
 
 if __name__ == "__main__":

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Example use: ./publish/publish_new_release_in_docker.py -- -m 3.4 -bt minor"""
+
 # Useful commands
 # # Build the docker file
 # > docker build -f resources/Dockerfile -t chiselrelease:latest .
@@ -137,7 +139,6 @@ def run_commands(container, environment, lines):
 def main():
     parser = makeParser()
     args = parser.parse_args()
-    print(args)
 
     # Check forwarded args
     forwarded_args = args.args

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -190,6 +190,8 @@ def main():
             "git clone git@github.com:ucb-bar/chisel-release.git",
             f"git config --global user.email {args.email}",
             f"git config --global user.name {args.name}",
+            # This is needed for pushing tags at the end of release during test_new_release.py
+            'git config --global url."git@github.com:".insteadOf "https://github.com/"',
         ]
         run_commands(container, {}, cmds)
 
@@ -218,6 +220,14 @@ def main():
     ]
 
     run_commands(container, environment, lines)
+
+    # Step 3 - Finalize Release on Sonatype
+    # See docs/sonatype_finalize_release.md
+    # TODO integrate into publish_new_release
+
+    # Step 4 - Tag Release
+    # Run publish/tag_new_release.py
+    # TODO integrate into publish_new_release
 
 
 if __name__ == "__main__":

--- a/publish/publish_new_release_in_docker.py
+++ b/publish/publish_new_release_in_docker.py
@@ -4,7 +4,7 @@
 
 # Useful commands
 # # Build the docker file
-# > docker build -f resources/Dockerfile -t chiselrelease:latest .
+# > docker build -f resources/Dockerfile -t ucbbar/chisel-release:latest .
 #
 # # Connect to a running container
 # > docker exec -it <container> bash
@@ -145,12 +145,12 @@ def main():
     pnr_parser = pnr.make_parser()
     pnr_parser.parse_args(forwarded_args)
 
-    image_name = "chiselrelease:latest"
+    image_name = "ucbbar/chisel-release:latest"
 
     # Step 1 - Build Docker Image
     # TODO actually do this
     # Run from root of the repo
-    # docker build -f resources/Dockerfile -t chiselrelease:latest .
+    # docker build -f resources/Dockerfile -t ucbbar/chisel-release:latest .
 
     # Environment needed to run publish commands
     environment = formatValues({

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -690,7 +690,7 @@ class Tools:
              git submodule foreach '
                  rbranch=$(git config -f $toplevel/.gitmodules submodule.$name.branch);
                  xbranch=$(echo $rbranch | sed -e "s/-release/.x/");
-                 {subcommand} git tag $(../genTag.sh $xbranch)
+                 {subcommand} git tag $(bash ../genTag.sh $xbranch)
              '
         """
 

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -379,28 +379,32 @@ class Tools:
     def run_make_clean_install(self, step_number):
         """run make clean install"""
 
+        # FIXME make clean is not threadsafe, must use -j1 until that is fixed
+        command = f"make -j1 -f {self.default_makefile} clean install"
         command_result = self.run_command(
-            f"make -j1 -f {self.default_makefile} clean install",
+            command,
             shell=True,
             capture_output=False)
 
         if command_result.returncode != 0:
             print(
-                f"make -j4 -f {self.default_makefile} clean install failed ({command_result.returncode}), see {self.log_name} for details")
+                f"{command} failed ({command_result.returncode}), see {self.log_name} for details")
             exit(1)
 
     @command_step
     def run_make_clean(self, step_number):
         """run make clean"""
 
+        # FIXME make clean is not threadsafe, must use -j1 until that is fixed
+        command = f"make -j1 -f {self.default_makefile} clean"
         command_result = self.run_command(
-            f"make -j4 -f {self.default_makefile} clean",
+            command,
             shell=True,
             capture_output=False)
 
         if command_result.returncode != 0:
             print(
-                f"make -j4 -f {self.default_makefile} clean failed ({command_result.returncode}), see {self.log_name} for details")
+                f"{command} failed ({command_result.returncode}), see {self.log_name} for details")
             exit(1)
 
     @command_step

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -468,7 +468,7 @@ class Tools:
         """verify merge"""
 
         command = Tools.get_versioning_command("verify")
-        command_result = self.run_command(f"{command} >& {self.log_name}", shell=True, capture_output=False)
+        command_result = self.run_command(f"{command}", shell=True, capture_output=False)
 
         if command_result.returncode != 0:
             print(f"{command} failed with error {command_result.returncode}, see {self.log_name} for details")

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -380,7 +380,7 @@ class Tools:
         """run make clean install"""
 
         command_result = self.run_command(
-            f"make -j4 -f {self.default_makefile} clean install",
+            f"make -j1 -f {self.default_makefile} clean install",
             shell=True,
             capture_output=False)
 

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -166,7 +166,7 @@ class Tools:
                 ", rc-clear, ds, ds<YYYMMDD>, ds-clear")
             exit(1)
 
-        return f"python {right_python_path}/{versioning_script} {args}"
+        return f"python3 {right_python_path}/{versioning_script} {args}"
 
     def run_command(self, *args, **kwargs):
         """wrapper that writes command itself and it's output to the log file, appending to existing file if there"""
@@ -493,7 +493,7 @@ class Tools:
         command = f"""
         git submodule foreach '
           cd .. &&
-          python $PYTHONPATH/repoissues2db/repoissues2db.py -r $name -s {date_stamp} {clear_db_flag}
+          python3 $PYTHONPATH/repoissues2db/repoissues2db.py -r $name -s {date_stamp} {clear_db_flag}
         '
         """
 
@@ -564,7 +564,7 @@ class Tools:
         command += f"""         grep -v SNAPSHOT | tail -n 2));\n"""
         command += """         echo $name ${tags[1]};\n"""
         command += """         echo $name ${tags[1]} >> ../changelog.txt;\n"""
-        command += f"""         python {self.execution_dir}/../../src/gitlog2releasenotes/gitlog2releasenotes.py """
+        command += f"""         python3 {self.execution_dir}/../../src/gitlog2releasenotes/gitlog2releasenotes.py """
         command += """                  -b git-$name releaseNotes.${tags[1]} >> ../changelog.txt\n"""
         command += f"""     fi\n"""
         command += f""" '\n"""

--- a/publish/publish_utils/tools.py
+++ b/publish/publish_utils/tools.py
@@ -454,13 +454,14 @@ class Tools:
         is_external_program_present(f"yosys -V")
         is_external_program_present(f"z3 --version")
 
+        command = f"make -j4 -f {self.default_makefile} test"
         command_result = self.run_command(
-            f"make -j4 -f {self.default_makefile} test",
+            command,
             shell=True,
             capture_output=False)
 
         if command_result.returncode != 0:
-            print(f"make -j4 -f {self.default_makefile} clean install failed, see {self.log_name} for details")
+            print(f"{command} failed, see {self.log_name} for details")
             show_errors()
             exit(1)
 

--- a/publish/tag_new_release.py
+++ b/publish/tag_new_release.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """tags release branches"""
 
 import os

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -33,3 +33,5 @@ WORKDIR /work/chisel-repo-tools/
 
 RUN pip3 install -r resources/requirements.txt
 
+WORKDIR /work
+

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04
+
+# DEBIAN_FRONTEND=noninteractive suppresses interactive localization questions
+# See https://askubuntu.com/questions/909277
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  curl \
+  gawk \
+  gnupg2 \
+  openjdk-11-jdk \
+  python3 \
+  python3-pip \
+  python3-venv \
+  verilator \
+  vim \
+  yosys \
+  z3
+
+# Add SBT repo
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+  echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+  curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+
+# Install SBT
+RUN apt-get update && apt-get install -y \
+  sbt
+
+WORKDIR /work
+
+COPY . chisel-repo-tools/
+
+WORKDIR /work/chisel-repo-tools/
+
+RUN pip3 install -r resources/requirements.txt
+

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -25,6 +25,8 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
 RUN apt-get update && apt-get install -y \
   sbt
 
+COPY resources/publish_plugins.sbt /root/.sbt/1.0/plugins/publish.sbt
+
 WORKDIR /work
 
 COPY . chisel-repo-tools/

--- a/resources/publish_plugins.sbt
+++ b/resources/publish_plugins.sbt
@@ -1,0 +1,3 @@
+// Required for +publishSigned in SBT
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -9,9 +9,7 @@ GitPython==3.1.11
 idna==2.10
 jwcrypto==0.8
 pycparser==2.20
-pygit==0.1
 PyGithub==1.53
-pygithub3==0.5.1
 PyJWT==1.7.1
 python-dateutil==2.8.1
 PyYAML==5.4.1

--- a/scripts/genTag.sh
+++ b/scripts/genTag.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 script_dir=$(dirname $0)
 xbranch="master"
 if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
All of the work I did to release Chisel v3.4.4

This adds `publish/publish_new_release_in_docker.py` that runs `publish_new_release.py` inside of a Docker container.
The added script has some useful Docker commands in it, especially because the last step of actually tagging the release isn't currently handled and requires doing a `docker exec` to run another session in the container.

This is one step toward more reproducible builds. I ran this both on my Laptop and on an Ubuntu Desktop. It's currently only tested using Docker _without sudo_ and using Keychain (whether on MacOS or Ubuntu).

The test step almost always fails spuriously which is pretty annoying, so that will have to be resolved before we can put this in CI. We also need to automate the last 2 steps of actually publishing the release on Sonatype and tagging (the latter is already automated but has to run after the former which is not).

The basic use is:
```bash
./publish/publish_new_release_in_docker.py <args to outer script> -- <args to publish_new_release.py>

# Release 3.4.<next>
./publish/publish_new_release_in_docker.py -- -m 3.4 -bt minor
```
