### PR TITLE
Dockerized Release

### DIFF
--- a/resources/Makefile
+++ b/resources/Makefile
@@ -25,7 +25,7 @@ default: install
 # For the first approach, we need to execute sbt commands in a specific
 # directory order and possibly do a publishLocal at the end so the results
 # are available to later submodules.
-EXPLICIT_SUBMODULES=firrtl firrtl-interpreter treadle chisel3 chisel-testers2 chisel-testers diagrammer dsptools
+EXPLICIT_SUBMODULES=firrtl firrtl-interpreter treadle chisel3 chiseltest chisel-testers diagrammer dsptools
 
 # The following targets need a publishLocal so their results are available.
 NEED_PUBLISHING = compile test +compile +test
@@ -156,7 +156,7 @@ test check:	test_projects $(NEED_INSTALL)
 # them.
 .PHONY: check clean clean_projects $(CLEAN_PROJECTS) clean_caches clean_artifacts compile coverage pull install install_projects $(INSTALL_PROJECTS) require_clean_work_tree test test_projects $(TEST_PROJECTS)
 
-BUILD_SBTs=chisel-testers/build.sbt chisel-testers2/build.sbt chisel3/build.sbt diagrammer/build.sbt dsptools/build.sbt firrtl/build.sbt firrtl-interpreter/build.sbt treadle/build.sbt
+BUILD_SBTs=chisel-testers/build.sbt chiseltest/build.sbt chisel3/build.sbt diagrammer/build.sbt dsptools/build.sbt firrtl/build.sbt firrtl-interpreter/build.sbt treadle/build.sbt
 
 stamps:
 	$(MKDIR) -p $@

--- a/resources/lookup_cmd.sh
+++ b/resources/lookup_cmd.sh
@@ -2,7 +2,7 @@
 
 # Logic for subbing commands in the Makefile
 case "$1$2" in
-  'chisel-testers2+test') echo '+testOnly -- -l RequiresVcs';;
+  'chiseltest+test') echo '+testOnly -- -l RequiresVcs';;
   *) echo $2;;
 esac
 

--- a/src/version/Version.py
+++ b/src/version/Version.py
@@ -26,7 +26,7 @@ from argparse import RawDescriptionHelpFormatter
 __all__ = []
 __version__ = 0.1
 __date__ = '2019-10-08'
-__updated__ = '2019-10-08'
+__updated__ = '2022-01-11'
 
 DEBUG = 1
 TESTRUN = 0
@@ -57,11 +57,14 @@ class CNVersion:
 
     def bumpMajor(self) -> 'CNVersion':
         someInts = list(self.theInts)
-        someInts[1] += 1
+        # If previous version is a release candidate (common case), we're just removing the RC#
+        if self.releaseQualifier is None:
+            someInts[1] += 1
         # If this is a SNAPSHOT version, don't touch the existing minor version (None).
         if someInts[2] is not None:
             someInts[2] = 0
-        return CNVersion(aVersion=self, theInts=someInts)
+        # Do not pass aVersion because major version should have qualifiers cleared
+        return CNVersion(theInts=someInts)
 
     def bumpMinor(self) -> 'CNVersion':
         someInts = list(self.theInts)


### PR DESCRIPTION
Keeping track of changes I needed to make to do the 3.5.0 release:

I also had to make manual edits to chisel-release. I did the same change basically on master, 3.5.x, and 3.5-release: https://github.com/ucb-bar/chisel-release/commit/003f1c5289081d387cad10c2cb5da2aac24c2023 (that's from 3.5-release). Deleting `chisel-template` and `chisel-tutorial` was somewhat arbitrary but they aren't really being released properly (see their versions) so it was a useful simplification. The main change has been renaming chisel-testers2 -> chiseltest (we very much lack single source of truth on this stuff...)