### PR TITLE
Changes needed to release 3.6.0-RC1 and 3.6.0-RC2

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH="$PATH:/opt/oss-cad-suite/bin"
 # Download firtool
 RUN mkdir -p circt
 
-RUN wget https://github.com/llvm/circt/releases/download/firtool-1.30.0/circt-bin-ubuntu-20.04.tar.gz -O - | tar -zx -C circt/
+RUN wget https://github.com/llvm/circt/releases/download/firtool-1.31.0/circt-bin-ubuntu-20.04.tar.gz -O - | tar -zx -C circt/
 
 ENV PATH="$PATH:/opt/circt/bin"
 

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -30,10 +30,10 @@ RUN tar zxvf oss-cad-suite-linux-x64-20220207.tgz
 # For some reason, the iverilog from oss-cad-suite doesn't seem to work right
 ENV PATH="$PATH:/opt/oss-cad-suite/bin"
 
-# Download CIRCT
+# Download firtool
 RUN mkdir -p circt
 
-RUN wget https://github.com/llvm/circt/releases/download/sifive%2F1%2F22%2F1/circt-bin-ubuntu-20.04.tar.gz -O - | tar -zx -C circt/
+RUN wget https://github.com/llvm/circt/releases/download/firtool-1.30.0/circt-bin-ubuntu-20.04.tar.gz -O - | tar -zx -C circt/
 
 ENV PATH="$PATH:/opt/circt/bin"
 

--- a/src/versioning/versioning.py
+++ b/src/versioning/versioning.py
@@ -218,7 +218,7 @@ class WorkContext:
         self.findMinor = findMinor
         self.version = None
         self.moduleVersionMap = None
-        self.recurse = True
+        self.recurse = False
         self.dryRun = args.dryRun
         self.output = args.output
 


### PR DESCRIPTION
chisel3 now has chisel3/website/build.sbt and we don't want to include that in versioning checking.